### PR TITLE
Add Python 3 compatbility

### DIFF
--- a/octoprint_PrusaETAOverride/__init__.py
+++ b/octoprint_PrusaETAOverride/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import octoprint.plugin
 import re
 import time
@@ -65,6 +65,7 @@ def pETAfactory(*args, **kwargs):
 
 
 __plugin_name__ = "Prusa ETA override Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 
 def __plugin_load__():


### PR DESCRIPTION
Good news! All it took was importing unicode_literals so I didn't have to mark each string with a `u`. Added Python 3 compatibility flag too.
Once this has been merged you can create a new release and I'll add mark it as compatible in the repo.