### PR TITLE
Rewrite a little and support SILENT mode.

### DIFF
--- a/octoprint_PrusaETAOverride/__init__.py
+++ b/octoprint_PrusaETAOverride/__init__.py
@@ -1,36 +1,68 @@
 # coding=utf-8
 from __future__ import absolute_import, unicode_literals
-import octoprint.plugin
+
+import logging
 import re
 import time
+
+import octoprint.plugin
 from octoprint.printer.estimation import PrintTimeEstimator
-from octoprint.events import eventManager, Events
 
-eta = 0
-oldZ = 0.0
+class PrusaETAPrintTimeEstimator(PrintTimeEstimator):
+    def __init__(self, job_type):
+        super(PrusaETAPrintTimeEstimator, self).__init__(job_type)
+        self._logger = logging.getLogger("octoprint.plugins.PrusaETAOverride")
+        self.last_update = time.time()
+        self.estimated_time = -1
 
-ts = int(time.time())
-r = re.compile(
-    r'NORMAL MODE: Percent done: \d+; print time remaining in mins: (\d+)')
-p = re.compile(
-    r'^X:\d+\.\d+ Y:\d+\.\d+ Z:(\d+\.\d+) ')
-
-
-def pETAeveryLine(comm, line, *args, **kwargs):
-    global eta, r, ts
-    m = r.search(line)
-    if m:
-        eta = int(m.group(1)) * 60
-        ts = int(time.time())
-        comm._sendCommand("M114")
-    z = p.search(line)
-    if z:
-        newZ = float(z.group(1))
-        comm._callback.on_comm_z_change(newZ)
-    return line
+    def estimate(self, *args, **kwargs):
+        if self.estimated_time < 0:
+            self._logger.debug("self.estimated_time < 0: {}, calling default PrintTimeEstimator".format(self.estimated_time))
+            return PrintTimeEstimator.estimate(self, *args, **kwargs)
+        eta = self.estimated_time - (int(time.time() - self.last_update)), "estimate"
+        self._logger.debug("New eta calculated: {} (self.estimated_time: {}, self.last_update: {}".format(eta, self.estimated_time, self.last_update))
+        return eta
 
 
 class PrusaetaoverridePlugin(octoprint.plugin.OctoPrintPlugin):
+    def __init__(self):
+        self._logger = logging.getLogger("octoprint.plugins.PrusaETAOverride")
+
+        self._estimator = None
+
+        # do not match lines with negative progress ("... Percent done: -1; ...")
+        self.m73_pattern = re.compile(
+                r'(?P<mode>\w+) MODE: Percent done: (?P<progress>\d+); print time remaining in mins: (?P<eta>\d+)(?:; Change in mins: (?P<eta_change>-?\d+))?')
+        self.m114_pattern = re.compile(
+                r'^X:\d+\.\d+ Y:\d+\.\d+ Z:(?P<z>\d+\.\d+) ')
+
+
+    def parse_line(self, comm, line, *args, **kwargs):
+        m = self.m73_pattern.search(line)
+        if m:
+            mode = m.group('mode')
+            if mode != "NORMAL":
+                return line
+            self._estimator.estimated_time = int(m.group('eta')) * 60
+            self._estimator.last_update = int(time.time())
+            self._logger.debug("Parsed time update for mode {}: {}".format(mode, self._estimator.estimated_time))
+            comm._sendCommand("M114")
+            return line
+
+        z = self.m114_pattern.search(line)
+        if z:
+            newZ = float(z.group('z'))
+            comm._callback.on_comm_z_change(newZ)
+            self._logger.debug("Parsed Z update: {}".format(newZ))
+            return line
+
+        return line
+
+    def estimator_factory(self, *args, **kwargs):
+        def factory(*args, **kwargs):
+            self._estimator = PrusaETAPrintTimeEstimator(*args, **kwargs)
+            return self._estimator
+        return factory
 
     def get_update_information(self):
         return dict(
@@ -49,19 +81,6 @@ class PrusaetaoverridePlugin(octoprint.plugin.OctoPrintPlugin):
             )
         )
 
-
-class pETAPrintTimeEstimator(PrintTimeEstimator):
-    def __init__(self, job_type):
-        super(pETAPrintTimeEstimator, self).__init__(job_type)
-
-    def estimate(self, progress, printTime, cleanedPrintTime, statisticalTotalPrintTime, statisticalTotalPrintTimeType):
-        return eta - (int(time.time()) - ts), "estimate"
-
-
-def pETAfactory(*args, **kwargs):
-    return pETAPrintTimeEstimator
-
-
 __plugin_name__ = "Prusa ETA override Plugin"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
@@ -73,6 +92,6 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
-        "octoprint.comm.protocol.gcode.received": pETAeveryLine,
-        "octoprint.printer.estimation.factory": pETAfactory
+        "octoprint.comm.protocol.gcode.received": __plugin_implementation__.parse_line,
+        "octoprint.printer.estimation.factory": __plugin_implementation__.estimator_factory
     }

--- a/octoprint_PrusaETAOverride/__init__.py
+++ b/octoprint_PrusaETAOverride/__init__.py
@@ -17,7 +17,7 @@ p = re.compile(
 
 
 def pETAeveryLine(comm, line, *args, **kwargs):
-    global eta, r, ts, oldZ
+    global eta, r, ts
     m = r.search(line)
     if m:
         eta = int(m.group(1)) * 60
@@ -26,9 +26,7 @@ def pETAeveryLine(comm, line, *args, **kwargs):
     z = p.search(line)
     if z:
         newZ = float(z.group(1))
-        if newZ != oldZ:
-            eventManager().fire(Events.Z_CHANGE, {"new": newZ, "old": oldZ})
-            oldZ = newZ
+        comm._callback.on_comm_z_change(newZ)
     return line
 
 


### PR DESCRIPTION
Few changes:
- use on_comm_z_change callback instead of manually firing event on Z change
- adjust to keep everything in classes
- don't do m114 output matching if we already matched line with m73 output
- support firmware that sends only SILENT messages (this becomes useful when https://github.com/prusa3d/Prusa-Firmware/pull/2735 gets merged)